### PR TITLE
fix(Vehicle): Fix incorrect instance ID

### DIFF
--- a/SAMP.ahk
+++ b/SAMP.ahk
@@ -162,6 +162,7 @@ global SAMP_ISCORE_OFFSET                   := [0x24, 0x0, 0x0, 0x4]
 global SAMP_ISNPC_OFFSET                    := [0x4, 0x8, 0x4, 0x8]
 
 global SAMP_PLAYER_MAX                      := 1004
+global SAMP_VEHICLE_MAX                     := 2000
 
 
 ; ######################### Checkpoints #########################
@@ -1157,9 +1158,7 @@ GetVehicleId() {
         return -1
     }
 
-    vehicleCount := readDWORD(hGTA, vehpool + 0x0)
-
-    Loop, % vehicleCount {
+    Loop, % SAMP_VEHICLE_MAX {
         i := A_Index - 1
 
         listed := readDWORD(hGTA, vehpool + 0x3074 + i*4)
@@ -1494,7 +1493,7 @@ GetVehicleNumberPlate() {
         return ""
     }
     
-    Loop, 2000
+    Loop, % SAMP_VEHICLE_MAX
     {
         i := A_Index-1
         

--- a/SAMP.ahk
+++ b/SAMP.ahk
@@ -162,7 +162,6 @@ global SAMP_ISCORE_OFFSET                   := [0x24, 0x0, 0x0, 0x4]
 global SAMP_ISNPC_OFFSET                    := [0x4, 0x8, 0x4, 0x8]
 
 global SAMP_PLAYER_MAX                      := 1004
-global SAMP_VEHICLE_MAX                     := 2000
 
 
 ; ######################### Checkpoints #########################
@@ -1158,7 +1157,9 @@ GetVehicleId() {
         return -1
     }
 
-    Loop, % SAMP_VEHICLE_MAX {
+    vehicleCount := readDWORD(hGTA, vehpool + 0x0)
+
+    Loop, % vehicleCount + 1 {
         i := A_Index - 1
 
         listed := readDWORD(hGTA, vehpool + 0x3074 + i*4)
@@ -1492,9 +1493,10 @@ GetVehicleNumberPlate() {
         ErrorLevel := ERROR_READ_MEMORY
         return ""
     }
-    
-    Loop, % SAMP_VEHICLE_MAX
-    {
+
+    vehicleCount := readDWORD(hGTA, vehpool + 0x0)
+
+    Loop, % vehicleCount + 1 {
         i := A_Index-1
         
         listed := readDWORD(hGTA, vehpool + 0x3074 + i*4)


### PR DESCRIPTION
The vehicle count obtained from memory is variable, if it's the same as the current vehicle ID, it the `GetVehicleId` function will return -1;

This PR fixes that by adding +1 to the vehicle count.