### PR TITLE
feat(Weapon): Add `GetPlayerWeaponSlot` to get equipped weapon class slot

### DIFF
--- a/SAMP.ahk
+++ b/SAMP.ahk
@@ -831,6 +831,27 @@ GetPlayerWeaponName() {
 }
 
 /**
+ * Retrieve the player's equipped weapon slot (1 - 12)
+ *
+ * @category Local Player
+ * @returns The player's weapon slot as an integer, or -1 on failure
+ */
+GetPlayerWeaponSlot() {
+    if (!checkHandles())
+        return -1
+
+    slot := readMem(hGTA, 0xB7CDBC, 4, "int")
+
+    if (ErrorLevel) {
+        ErrorLevel := ERROR_READ_MEMORY
+        return -1
+    }
+
+    ErrorLevel := ERROR_OK
+    return slot
+}
+
+/**
  * Retrieve the player's state, e.g. on foot, driving, dead, ...
  * <p>
  * See [Player States | open.mp](https://open.mp/en/docs/scripting/resources/playerstates)

--- a/SAMP.ahk
+++ b/SAMP.ahk
@@ -46,6 +46,7 @@ global ADDR_CPED_ARMOROFF           := 0x548         ;Player Armour
 global ADDR_CPED_MONEY              := 0x0B7CE54     ;Player Money
 global ADDR_CPED_INTID              := 0xA4ACE8      ;Player Interior-ID
 global ADDR_CPED_SKINIDOFF          := 0x22          ;Player Skin-ID
+global ADDR_CPED_WEAPON_SLOT        := 0xB7CDBC      ;Player Current Weapon Slot
 ;
 global ADDR_VEHICLE_PTR             := 0xBA18FC      ;Vehicle CPED Pointer
 global ADDR_VEHICLE_HPOFF           := 0x4C0         ;Vehicle Health
@@ -840,7 +841,7 @@ GetPlayerWeaponSlot() {
     if (!checkHandles())
         return -1
 
-    slot := readMem(hGTA, 0xB7CDBC, 4, "int")
+    slot := readMem(hGTA, ADDR_CPED_WEAPON_SLOT, 4, "int")
 
     if (ErrorLevel) {
         ErrorLevel := ERROR_READ_MEMORY

--- a/docs/docs/functions/Local Player/GetPlayerWeaponSlot.md
+++ b/docs/docs/functions/Local Player/GetPlayerWeaponSlot.md
@@ -2,7 +2,7 @@
 title: GetPlayerWeaponSlot
 ---
 
-Retrieve the player's currently equipped weapon slot (Pistols, Shotguns, Automatic Rifles, etc.)
+Retrieve the player's equipped weapon slot (1 - 12)
 
 **Returns:** The player's weapon slot as an integer, or -1 on failure
 

--- a/docs/docs/functions/Local Player/GetPlayerWeaponSlot.md
+++ b/docs/docs/functions/Local Player/GetPlayerWeaponSlot.md
@@ -1,0 +1,13 @@
+---
+title: GetPlayerWeaponSlot
+---
+
+Retrieve the player's currently equipped weapon slot (Pistols, Shotguns, Automatic Rifles, etc.)
+
+**Returns:** The player's weapon slot as an integer, or -1 on failure
+
+**Signature:**
+
+```autohotkey
+GetPlayerWeaponSlot()
+```


### PR DESCRIPTION
This PR adds a new function that retrieves the player's equipped weapon class slot.
There are 12 slots, each representing weapons of a specific type. For example, slot 2 are pistols such as the Colt 45 or Deagle.
Useful for automatized weapon switching for example.