### PR TITLE
feat: Add AHK requirements directives

### DIFF
--- a/SAMP.ahk
+++ b/SAMP.ahk
@@ -18,6 +18,10 @@
 ; Do not remove these lines.
 ; ####################
 
+#Requires AutoHotkey <2.0
+#Requires AutoHotkey 32-bit
+#Requires AutoHotkey ANSI
+
 ; ######################### Error levels #########################
 global ERROR_OK                     := 0
 global ERROR_PROCESS_NOT_FOUND      := 1

--- a/TestKeybinder.ahk
+++ b/TestKeybinder.ahk
@@ -1,4 +1,8 @@
 ; https://github.com/paul-phoenix/SAMP-UDF-for-AutoHotKey/blob/2b8a567ad29550bfce9196c182f58fa85c0f4d78/SAMP.ahk
+#Requires AutoHotkey <2.0
+#Requires AutoHotkey 32-bit
+#Requires AutoHotkey ANSI
+
 SendMode Input
 SetWorkingDir %A_ScriptDir%
 #Warn


### PR DESCRIPTION
This PR adds AHK requirements in order the execute or compile the script correctly.
If the script is executed or compiled with an incorrect AHK interpreter, an error will be thrown, letting the user know.

This should help prevent issues mentioned in #17 